### PR TITLE
emulator.sh: supports reading the ARCH from .config

### DIFF
--- a/emulator.sh
+++ b/emulator.sh
@@ -52,7 +52,7 @@ if test -e "$1/.config"; then
     EMULATOR_ARGS="-L ${EMULATOR_DIR}/share/qemu -kernel ${OUT_DIR}/nuttx $(cat ${OUT_DIR}/qemu_args.txt)"
     echo "RUN ${EMULATOR_BIN} ${EMULATOR_ARGS}"
     ${EMULATOR_BIN} ${EMULATOR_ARGS}
-  elif grep -q '^CONFIG_ARCH_CHIP_GOLDFISH=y' ${OUT_DIR}/.config; then
+  elif grep -Eq '^CONFIG_ARCH_CHIP_GOLDFISH_(ARM|ARM64|X86_64)=y' ${OUT_DIR}/.config; then
     mkdir -p ${OUT_DIR}/system
     echo "ro.product.cpu.abi=${QEMU_ARCH}" | sed 's/aarch64/arm64/g' > ${OUT_DIR}/system/build.prop
     export ANDROID_EMULATOR_VELA=true


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*Update this section with information on why change is necessary,
 what it exactly does and how, if new feature shows up, provide
 references (dependencies, similar problems and solutions), etc.*

## Impact

*Update this section, where applicable, on how change affects users,
 build process, hardware, documentation, security, compatibility, etc.*

## Testing

*Update this section with details on how did you verify the change,
 what Host was used for build (OS, CPU, compiler, ..), what Target was
 used for verification (arch, board:config, ..), etc. Providing build
 and runtime logs from before and after change is highly appreciated.*

