### PR TITLE
emulator: add second NIC for cellular data when WiFi SIM enabled

### DIFF
--- a/emulator.sh
+++ b/emulator.sh
@@ -100,6 +100,11 @@ if test -e "$1/.config"; then
     else
       EMULATOR_COMMON_ARGS="${EMULATOR_COMMON_ARGS} -qemu -device virtio-snd,bus=virtio-mmio-bus.2 -allow-host-audio"
     fi
+
+    # Add a second NIC (eth0) for cellular data when WiFi SIM occupies the first NIC (wlan0)
+    if grep -q '^CONFIG_WIFI_SIM_NUMBER=' ${OUT_DIR}/.config; then
+      EMULATOR_COMMON_ARGS="${EMULATOR_COMMON_ARGS} -qemu -netdev user,id=datanet -device virtio-net-device,netdev=datanet"
+    fi
     EMULATOR_EXTRA_ARGS="$@"
     EMULATOR_MERGED_ARGS=$(merge_args ${EMULATOR_COMMON_ARGS} ${EMULATOR_EXTRA_ARGS})
     echo "RUN ${EMULATOR_BIN} ${EMULATOR_MERGED_ARGS}"


### PR DESCRIPTION
## Summary

Emulator cannot currently enable the eth0 NIC. eth0 is used to simulate the telephony cellular data NIC, but currently only one NIC is configured, which defaults to wlan0, leaving no available telephony NIC in the system.

This change detects the CONFIG_WIFI_SIM_NUMBER configuration in the goldfish emulator startup script. If present, it creates an additional NIC via QEMU parameters (-netdev user,id=datanet -device virtio-net-device,netdev=datanet), generating an eth0 interface for telephony cellular data connection.

## Impact

- Only takes effect when CONFIG_WIFI_SIM_NUMBER is configured in .config
- Does not affect scenarios where WiFi SIM is not enabled
- Affects goldfish architecture emulator startup parameters
- No hardware, documentation, security, or compatibility impact

## Testing

- Build host: Linux x86_64
- Target: qemu goldfish arm64 with WiFi SIM configuration enabled
- Before: Running emulator then ifconfig shows no eth0 NIC
- After: Running emulator then ifconfig shows eth0; enabling cellular data in telephony allows eth0 to obtain IP and access the internet

Mirror of: https://gitee.com/huangcaihua/prebuilts_emulator_tools/pulls/1